### PR TITLE
Convert (InGame) design to full multi-stage

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -14,7 +14,7 @@ pub struct AnimationPlugin;
 impl Plugin for AnimationPlugin {
     fn build(&self, app: &mut App) {
         app.add_system_set_to_stage(
-            GameStage::Animation,
+            GameStage::Rendering,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
                 .with_system(animate_on_state_changed)

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -47,7 +47,8 @@ impl Plugin for AttackPlugin {
                 .with_system(enemy_attack)
                 .into(),
         )
-        .add_system_set(
+        .add_system_set_to_stage(
+            GameStage::Processing,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
                 .with_system(activate_hitbox)

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -6,7 +6,7 @@ use bevy::{
     math::{Vec2, Vec3},
     prelude::{
         default, App, AssetServer, Assets, Bundle, Commands, Component, Entity, EventReader,
-        Handle, Local, Parent, Plugin, Query, Res, Transform, With, Without,
+        Handle, Parent, Plugin, Query, Res, Transform, With, Without,
     },
     sprite::SpriteBundle,
     transform::TransformBundle,
@@ -303,7 +303,6 @@ fn player_flop(
     time: Res<Time>,
     left_movement_boundary: Res<LeftMovementBoundary>,
     game_meta: Res<GameMeta>,
-    mut start_y: Local<Option<f32>>,
 ) {
     let players_movement = query
         .iter_mut()
@@ -365,22 +364,10 @@ fn player_flop(
                         }
                     }
 
-                    // For currently unclear reasons, the first Animation frame may run for less Bevy frames
-                    // than expected. When this is the case, the player jumps less then it should, netting,
-                    // at the end of the animation, a slightly negative Y than the beginning, which causes
-                    // problems. This is a workaround.
-                    //
-                    if start_y.is_none() {
-                        *start_y = Some(transform.translation.y);
-                    }
-
                     if animation.current_frame < 1 {
                         movement.y += 180. * time.delta_seconds();
                     } else if animation.current_frame < 3 {
                         movement.y -= 90. * time.delta_seconds();
-                    } else if animation.is_finished() {
-                        movement.y = start_y.unwrap();
-                        *start_y = None;
                     }
 
                     (transform.translation, Some(movement))

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -30,29 +30,31 @@ use crate::{
         clamp_player_movements, LeftMovementBoundary, MoveInArc, MoveInDirection, Rotate, Target,
     },
     state::State,
-    ArrivedEvent, Enemy, GameState, Player, Stats,
+    ArrivedEvent, Enemy, GameStage, GameState, Player, Stats,
 };
 
 pub struct AttackPlugin;
 
 impl Plugin for AttackPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system_set(
+        app.add_system_set_to_stage(
+            GameStage::Actions,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
                 .with_system(player_projectile_attack)
                 .with_system(player_throw)
                 .with_system(player_flop)
+                .with_system(enemy_attack)
+                .into(),
+        )
+        .add_system_set(
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
                 .with_system(activate_hitbox)
                 .with_system(deactivate_hitbox)
                 .with_system(projectile_cleanup)
                 .with_system(projectile_tick)
                 .into(),
-        )
-        .add_system(
-            enemy_attack
-                .run_in_state(GameState::InGame)
-                .after("move_to_target"),
         );
     }
 }

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -40,13 +40,6 @@ impl Plugin for LoadingPlugin {
                 load_game
                     .run_in_state(GameState::LoadingGame)
                     .run_if(game_assets_loaded),
-            )
-            .add_system_set(
-                ConditionSet::new()
-                    .run_in_state(GameState::InGame)
-                    .with_system(load_fighters)
-                    .with_system(load_items)
-                    .into(),
             );
 
         // Configure hot reload
@@ -64,8 +57,24 @@ impl Plugin for LoadingPlugin {
                     .with_system(hot_reload_level)
                     .with_system(hot_reload_fighters)
                     .into(),
+            )
+            .add_stage_after(
+                GameStage::HotReload,
+                GameStage::Load,
+                SystemStage::parallel(),
             );
+        } else {
+            app.add_stage_after(CoreStage::Update, GameStage::Load, SystemStage::parallel());
         }
+
+        app.add_system_set_to_stage(
+            GameStage::Load,
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(load_fighters)
+                .with_system(load_items)
+                .into(),
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ enum GameStage {
     Load,
     Decisions,
     Actions,
+    Movement,
     Rendering,
     // Last: built-in stage; used only for the despawning system
 }
@@ -218,6 +219,22 @@ fn main() {
                 .into(),
         )
         .add_stage_after(
+            GameStage::Actions,
+            GameStage::Movement,
+            SystemStage::parallel(),
+        )
+        .add_system_set_to_stage(
+            GameStage::Movement,
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(move_to_target)
+                .with_system(move_direction_system)
+                .with_system(knockback_system) // performs the translation only
+                .with_system(move_in_arc_system)
+                .with_system(rotate_system)
+                .into(),
+        )
+        .add_stage_after(
             CoreStage::Update, // PLACEHOLDER
             GameStage::Rendering,
             SystemStage::parallel(),
@@ -259,18 +276,13 @@ fn main() {
                 .run_in_state(GameState::InGame)
                 .with_system(attack_fighter_collision)
                 .with_system(kill_entities)
-                .with_system(knockback_system)
-                .with_system(move_direction_system)
                 .into(),
         )
-        .add_system(move_to_target.run_in_state(GameState::InGame))
         .add_system(unpause.run_in_state(GameState::Paused))
         .add_system_set_to_stage(
             CoreStage::PostUpdate,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
-                .with_system(move_in_arc_system)
-                .with_system(rotate_system)
                 .with_system(update_left_movement_boundary)
                 .with_system(game_over_on_players_death)
                 .into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ enum GameStage {
     Decisions,
     Actions,
     Movement,
+    Collisions,
     Rendering,
     // Last: built-in stage; used only for the despawning system
 }
@@ -235,6 +236,18 @@ fn main() {
                 .into(),
         )
         .add_stage_after(
+            GameStage::Movement,
+            GameStage::Collisions,
+            SystemStage::parallel(),
+        )
+        .add_system_set_to_stage(
+            GameStage::Collisions,
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(attack_fighter_collision)
+                .into(),
+        )
+        .add_stage_after(
             CoreStage::Update, // PLACEHOLDER
             GameStage::Rendering,
             SystemStage::parallel(),
@@ -274,7 +287,6 @@ fn main() {
         .add_system_set(
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
-                .with_system(attack_fighter_collision)
                 .with_system(kill_entities)
                 .into(),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,8 @@ impl Default for Stats {
 enum GameStage {
     // Update: built-in stage; not used by this crate's systems
     // AssetStage stages (Bevy built-in)
-    HotReload,
+    HotReload, // Optional
+    Load,
     Rendering,
     // Last: built-in stage; used only for the despawning system
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ fn main() {
                 // other systems are added by AnimationPlugin
                 .into(),
         )
+        .add_system_to_stage(CoreStage::Last, despawn_entities)
         .add_event::<ArrivedEvent>()
         .add_loopless_state(GameState::LoadingStorage)
         .add_plugin(platform::PlatformPlugin)
@@ -256,8 +257,7 @@ fn main() {
                 .with_system(update_left_movement_boundary)
                 .with_system(game_over_on_players_death)
                 .into(),
-        )
-        .add_system_to_stage(CoreStage::Last, despawn_entities);
+        );
 
     // Add debug plugins
     #[cfg(feature = "debug")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ enum GameStage {
     HotReload, // Optional
     Load,
     Decisions,
+    Actions,
     Rendering,
     // Last: built-in stage; used only for the despawning system
 }
@@ -203,6 +204,20 @@ fn main() {
                 .into(),
         )
         .add_stage_after(
+            GameStage::Decisions,
+            GameStage::Actions,
+            SystemStage::parallel(),
+        )
+        .add_system_set_to_stage(
+            GameStage::Actions,
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(pick_items)
+                .with_system(pause) // not strictly an action, but requires input update
+                // other systems are added by AttackPlugin
+                .into(),
+        )
+        .add_stage_after(
             CoreStage::Update, // PLACEHOLDER
             GameStage::Rendering,
             SystemStage::parallel(),
@@ -242,19 +257,13 @@ fn main() {
         .add_system_set(
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
-                .with_system(pick_items)
                 .with_system(attack_fighter_collision)
                 .with_system(kill_entities)
                 .with_system(knockback_system)
                 .with_system(move_direction_system)
-                .with_system(pause)
                 .into(),
         )
-        .add_system(
-            move_to_target
-                .run_in_state(GameState::InGame)
-                .label("move_to_target"),
-        )
+        .add_system(move_to_target.run_in_state(GameState::InGame))
         .add_system(unpause.run_in_state(GameState::Paused))
         .add_system_set_to_stage(
             CoreStage::PostUpdate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,10 +83,15 @@ impl Default for Stats {
 /// Writes within a stage are not read by systems in the same stage, with the exception of ResMut
 /// updates.
 ///
+/// The variants are ordered in the order they're scheduled.
+///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, StageLabel)]
 enum GameStage {
-    Animation,
+    // Update: built-in stage; not used by this crate's systems
+    // AssetStage stages (Bevy built-in)
     HotReload,
+    Animation,
+    // Last: built-in stage; used only for the despawning system
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,9 +187,19 @@ fn main() {
     // Add other systems and resources
     app.insert_resource(ClearColor(Color::BLACK))
         .add_stage_after(
-            CoreStage::Update,
+            CoreStage::Update, // PLACEHOLDER
             GameStage::Rendering,
             SystemStage::parallel(),
+        )
+        .add_system_set_to_stage(
+            GameStage::Rendering,
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(y_sort)
+                .with_system(camera_follow_player)
+                .with_system(fighter_sound_effect)
+                // other systems are added by AnimationPlugin
+                .into(),
         )
         .add_event::<ArrivedEvent>()
         .add_loopless_state(GameState::LoadingStorage)
@@ -218,7 +228,6 @@ fn main() {
                 .run_in_state(GameState::InGame)
                 .with_system(player_controller)
                 .with_system(pick_items)
-                .with_system(y_sort)
                 .with_system(attack_fighter_collision)
                 .with_system(kill_entities)
                 .with_system(knockback_system)
@@ -244,9 +253,7 @@ fn main() {
                 .run_in_state(GameState::InGame)
                 .with_system(move_in_arc_system)
                 .with_system(rotate_system)
-                .with_system(camera_follow_player)
                 .with_system(update_left_movement_boundary)
-                .with_system(fighter_sound_effect)
                 .with_system(game_over_on_players_death)
                 .into(),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ enum GameStage {
     Load,
     Decisions,
     Actions,
+    Processing,
     Movement,
     Collisions,
     PreRendering,
@@ -222,6 +223,19 @@ fn main() {
         )
         .add_stage_after(
             GameStage::Actions,
+            GameStage::Processing,
+            SystemStage::parallel(),
+        )
+        .add_system_set_to_stage(
+            GameStage::Processing,
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(kill_entities)
+                // other systems are added by AttackPlugin and StatePlugin
+                .into(),
+        )
+        .add_stage_after(
+            GameStage::Processing,
             GameStage::Movement,
             SystemStage::parallel(),
         )
@@ -229,6 +243,7 @@ fn main() {
             GameStage::Movement,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
+                .with_system(kill_entities)
                 .with_system(move_to_target)
                 .with_system(move_direction_system)
                 .with_system(knockback_system) // performs the translation only
@@ -257,7 +272,6 @@ fn main() {
             GameStage::PreRendering,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
-                .with_system(kill_entities)
                 .with_system(update_left_movement_boundary)
                 .with_system(game_over_on_players_death)
                 // other systems are added by StatePlugin

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ enum GameStage {
     // Update: built-in stage; not used by this crate's systems
     // AssetStage stages (Bevy built-in)
     HotReload,
-    Animation,
+    Rendering,
     // Last: built-in stage; used only for the despawning system
 }
 
@@ -188,7 +188,7 @@ fn main() {
     app.insert_resource(ClearColor(Color::BLACK))
         .add_stage_after(
             CoreStage::Update,
-            GameStage::Animation,
+            GameStage::Rendering,
             SystemStage::parallel(),
         )
         .add_event::<ArrivedEvent>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,11 @@ impl Default for Stats {
     }
 }
 
+/// Stages are used as command transactions - each stage will read the commands flushed by the
+/// previous one, and will apply the writes that will be read by the next.
+/// Writes within a stage are not read by systems in the same stage, with the exception of ResMut
+/// updates.
+///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, StageLabel)]
 enum GameStage {
     Animation,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,13 +1,20 @@
-use bevy::prelude::{App, Component, CoreStage, Plugin, Query};
+use bevy::prelude::{App, Component, Plugin, Query};
+use iyes_loopless::prelude::ConditionSet;
 use serde::Deserialize;
 
-use crate::animation::Animation;
+use crate::{animation::Animation, GameStage, GameState};
 
 pub struct StatePlugin;
 
 impl Plugin for StatePlugin {
     fn build(&self, app: &mut App) {
-        app.add_system_to_stage(CoreStage::PostUpdate, return_to_idle);
+        app.add_system_set_to_stage(
+            GameStage::PreRendering,
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(return_to_idle) // maybe state changes should run in the Decisions stage 🤔
+                .into(),
+        );
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,10 +9,10 @@ pub struct StatePlugin;
 impl Plugin for StatePlugin {
     fn build(&self, app: &mut App) {
         app.add_system_set_to_stage(
-            GameStage::PreRendering,
+            GameStage::Processing,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
-                .with_system(return_to_idle) // maybe state changes should run in the Decisions stage 🤔
+                .with_system(return_to_idle)
                 .into(),
         );
     }


### PR DESCRIPTION
Create a (InGame) design fully based on Bevy stages, for the reasons explained in #99.

This fixed at least on bug! See 7e9e854815.

Note that there is an existing issue, which is unrelated to this PR - if the flop is executed at the top location, the player will only go down.

I've tested this change for minutes 10, maybe more, with different cycles, and didn't find any issue, but unfortunately, this type of change may introduce subtle bugs.

I think that the stages introduced are consistent; the "Processing" name is something I find a bit too generic (but I couldn't find any better). Of course the PR is open to changes 😄.

Closes #99.