### PR TITLE
Improve AI targeting

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,6 +3,10 @@ pub const PLAYER_SPRITE_HEIGHT: f32 = 80.;
 pub const PLAYER_HITBOX_HEIGHT: f32 = 50.;
 
 pub const PLAYER_HEIGHT: f32 = PLAYER_SPRITE_HEIGHT - 50.;
+
+/// Absolute value.
+pub const ENEMY_TARGET_MAX_OFFSET: f32 = 100.;
+
 // Distance from the player, after which the player movement boundary is moved forward.
 //
 pub const LEFT_BOUNDARY_MAX_DISTANCE: f32 = 380.;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -7,6 +7,9 @@ pub const PLAYER_HEIGHT: f32 = PLAYER_SPRITE_HEIGHT - 50.;
 /// Absolute value.
 pub const ENEMY_TARGET_MAX_OFFSET: f32 = 100.;
 
+pub const ENEMY_MIN_ATTACK_DISTANCE: f32 = 5.;
+pub const ENEMY_MAX_ATTACK_DISTANCE: f32 = 100.;
+
 // Distance from the player, after which the player movement boundary is moved forward.
 //
 pub const LEFT_BOUNDARY_MAX_DISTANCE: f32 = 380.;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -5,7 +5,7 @@ pub const PLAYER_HITBOX_HEIGHT: f32 = 50.;
 pub const PLAYER_HEIGHT: f32 = PLAYER_SPRITE_HEIGHT - 50.;
 
 /// Absolute value.
-pub const ENEMY_TARGET_MAX_OFFSET: f32 = 100.;
+pub const ENEMY_TARGET_MAX_OFFSET: f32 = 40.;
 
 pub const ENEMY_MIN_ATTACK_DISTANCE: f32 = 5.;
 pub const ENEMY_MAX_ATTACK_DISTANCE: f32 = 100.;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use bevy_kira_audio::{AudioApp, AudioPlugin};
 use bevy_parallax::{ParallaxPlugin, ParallaxResource};
 use bevy_rapier2d::prelude::*;
 use consts::ENEMY_TARGET_MAX_OFFSET;
+use consts::{ENEMY_MAX_ATTACK_DISTANCE, ENEMY_MIN_ATTACK_DISTANCE};
 use enemy::*;
 use input::MenuAction;
 use iyes_loopless::prelude::*;
@@ -355,12 +356,17 @@ fn set_target_near_player(
                             rng.gen_range(-ENEMY_TARGET_MAX_OFFSET..ENEMY_TARGET_MAX_OFFSET);
                         let y_offset =
                             rng.gen_range(-ENEMY_TARGET_MAX_OFFSET..ENEMY_TARGET_MAX_OFFSET);
+
+                        let attack_distance =
+                            rng.gen_range(ENEMY_MIN_ATTACK_DISTANCE..ENEMY_MAX_ATTACK_DISTANCE);
+
                         commands.entity(e_entity).insert(Target {
                             position: Vec2::new(
                                 p_transform.translation.x + x_offset,
                                 (p_transform.translation.y + y_offset)
                                     .clamp(consts::MIN_Y, consts::MAX_Y),
                             ),
+                            attack_distance,
                         });
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use bevy::{
 use bevy_kira_audio::{AudioApp, AudioPlugin};
 use bevy_parallax::{ParallaxPlugin, ParallaxResource};
 use bevy_rapier2d::prelude::*;
+use consts::ENEMY_TARGET_MAX_OFFSET;
 use enemy::*;
 use input::MenuAction;
 use iyes_loopless::prelude::*;
@@ -350,8 +351,10 @@ fn set_target_near_player(
                     if max_player_x > e_trip_point_x.0 {
                         e_trip_point_x.0 = f32::MIN;
 
-                        let x_offset = rng.gen_range(-100.0..100.);
-                        let y_offset = rng.gen_range(-100.0..100.);
+                        let x_offset =
+                            rng.gen_range(-ENEMY_TARGET_MAX_OFFSET..ENEMY_TARGET_MAX_OFFSET);
+                        let y_offset =
+                            rng.gen_range(-ENEMY_TARGET_MAX_OFFSET..ENEMY_TARGET_MAX_OFFSET);
                         commands.entity(e_entity).insert(Target {
                             position: Vec2::new(
                                 p_transform.translation.x + x_offset,

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -259,19 +259,29 @@ pub fn move_to_target(
             transform.translation += (target.position.extend(0.) - translation_old).normalize()
                 * stats.movement_speed
                 * time.delta_seconds();
-            if transform.translation.x > translation_old.x {
-                *facing = Facing::Right;
-            } else {
-                *facing = Facing::Left;
-            }
 
             let target_distance = transform.translation.truncate().distance(target.position);
 
             if target_distance <= target.attack_distance {
+                // Note that the target includes an offset, so this can still not point to the
+                // player.
+
+                *facing = if target.position.x > transform.translation.x {
+                    Facing::Right
+                } else {
+                    Facing::Left
+                };
+
                 commands.entity(entity).remove::<Target>();
                 *state = State::Idle;
                 event_writer.send(ArrivedEvent(entity))
             } else {
+                *facing = if transform.translation.x > translation_old.x {
+                    Facing::Right
+                } else {
+                    Facing::Left
+                };
+
                 *state = State::Running;
             }
         }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -230,10 +230,16 @@ pub fn rotate_system(mut query: Query<(&mut Transform, &Rotate)>, time: Res<Time
     }
 }
 
+/// Target belonging to an enemy (therefore, the player).
+/// The attack distance is for randomization purposes, and it's the distance that triggers the
+/// attack. More precisely, it's the max distance - if the enemy finds itself at a smaller
+/// distance, it will attack.
 #[derive(Component)]
 pub struct Target {
     pub position: Vec2,
+    pub attack_distance: f32,
 }
+
 pub fn move_to_target(
     mut query: Query<(
         Entity,
@@ -258,7 +264,10 @@ pub fn move_to_target(
             } else {
                 *facing = Facing::Left;
             }
-            if transform.translation.truncate().distance(target.position) <= 100. {
+
+            let target_distance = transform.translation.truncate().distance(target.position);
+
+            if target_distance <= target.attack_distance {
                 commands.entity(entity).remove::<Target>();
                 *state = State::Idle;
                 event_writer.send(ArrivedEvent(entity))


### PR DESCRIPTION
A mix of tweaks and new logic.

The PR is intended to be the most minimal change that makes a noticeable difference; the main change has been to add an attack distance to Target, which is now randomized (and, in average, smaller), rather than being hardcoded to 100.

On attack, enemies will now always face the target (note: this is not necessarily the player position, but the effect is noticeably better), which looks better, and also improves the attack itself.

The enemy target max offset has also been reduced to 40.

Closes #155.