### PR TITLE
Allow Configuring Debug Tools at Runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,17 +48,16 @@ directories = "4.0.1"
 async-channel = "1.6.1"
 once_cell = "1.13.0"
 
-# Waiting for updates to Bevy 0.8
+# Debug tools
+bevy-inspector-egui = { version = "0.12.1" }
+bevy-inspector-egui-rapier = { version = "0.5.0", features = ["rapier2d"] }
 bevy_mod_debugdump = { version = "0.5.0", optional = true }
-bevy-inspector-egui = { version = "0.12.1", optional = true }
-bevy-inspector-egui-rapier = { version = "0.5.0", optional = true, features = ["rapier2d"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["Window","Location","Storage"] }
 
 [features]
 default = []
-debug = ["bevy_mod_debugdump", "bevy-inspector-egui", "bevy-inspector-egui-rapier"]
 schedule_graph = ["bevy_mod_debugdump"]
 
 # Enable optimizations for dependencies but not for our code

--- a/assets/locales/en-US/main.ftl
+++ b/assets/locales/en-US/main.ftl
@@ -31,3 +31,8 @@ flop-attack = Flop Attack
 shoot = Shoot
 throwgrab = Throw/Grab
 bind-input = Press an input or press Escape to cancel.
+
+# Debug Tools
+debug-tools = Debug Tools
+show-collision-shapes = Show Collision Shapes
+show-world-inspector = Show World Inspector

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -14,14 +14,18 @@ pub struct AnimationPlugin;
 
 impl Plugin for AnimationPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system_set_to_stage(
-            CoreStage::Last,
-            ConditionSet::new()
-                .run_in_state(GameState::InGame)
-                .with_system(animation_flipping)
-                .with_system(animation_cycling)
-                .into(),
-        );
+        app
+            // Register reflect types
+            .register_type::<Facing>()
+            // Add systems
+            .add_system_set_to_stage(
+                CoreStage::Last,
+                ConditionSet::new()
+                    .run_in_state(GameState::InGame)
+                    .with_system(animation_flipping)
+                    .with_system(animation_cycling)
+                    .into(),
+            );
     }
 }
 
@@ -33,11 +37,17 @@ pub struct AnimatedSpriteSheetBundle {
     pub animation: Animation,
 }
 
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, PartialEq, Eq, Clone)]
+#[derive(Component, PartialEq, Eq, Clone, Reflect)]
+#[reflect(Component)]
 pub enum Facing {
     Left,
     Right,
+}
+
+impl Default for Facing {
+    fn default() -> Self {
+        Self::Right
+    }
 }
 
 impl Facing {

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -1,11 +1,4 @@
-use bevy::{
-    hierarchy::DespawnRecursiveExt,
-    math::Vec2,
-    prelude::{
-        App, Commands, Component, CoreStage, Entity, EventReader, EventWriter, Parent, Plugin,
-        Query, With, Without,
-    },
-};
+use bevy::{hierarchy::DespawnRecursiveExt, math::Vec2, prelude::*, reflect::Reflect};
 use bevy_rapier2d::prelude::*;
 use iyes_loopless::prelude::*;
 
@@ -21,6 +14,8 @@ pub struct AttackPlugin;
 impl Plugin for AttackPlugin {
     fn build(&self, app: &mut App) {
         app
+            // Register reflect types
+            .register_type::<Attack>()
             // Add systems
             .add_system_set(
                 ConditionSet::new()
@@ -35,8 +30,8 @@ impl Plugin for AttackPlugin {
 }
 
 /// A component representing an attack that can do damage to [`Damageable`]s with [`Health`].
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, Clone, Copy)]
+#[derive(Component, Clone, Copy, Default, Reflect)]
+#[reflect(Component)]
 pub struct Attack {
     pub damage: i32,
     /// The direction and speed that the attack is hitting something in.

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -2,7 +2,7 @@
 // Also for cleanness (named channels have evident function), we don't use the default channel.
 
 use bevy::{prelude::*, utils::HashMap};
-use bevy_kira_audio::{AudioChannel, AudioSource};
+use bevy_kira_audio::{AudioApp, AudioChannel, AudioSource};
 use iyes_loopless::prelude::*;
 
 use crate::{
@@ -32,6 +32,11 @@ pub struct AudioPlugin;
 impl Plugin for AudioPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(bevy_kira_audio::AudioPlugin)
+            .add_audio_channel::<MusicChannel>()
+            .add_audio_channel::<EffectsChannel>()
+            .add_startup_system(set_audio_channels_volume)
+            .add_enter_system(GameState::InGame, play_level_music)
+            .add_exit_system(GameState::InGame, stop_level_music)
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 animation_audio_playback.run_in_state(GameState::InGame),

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -8,20 +8,24 @@ pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system_set_to_stage(
-            CoreStage::PostUpdate,
-            ConditionSet::new()
-                .run_in_state(GameState::InGame)
-                .after(VelocitySystems)
-                .with_system(camera_follow_player)
-                .with_system(y_sort)
-                .into(),
-        );
+        app
+            // Register reflect types
+            .register_type::<YSort>()
+            // Add systems
+            .add_system_set_to_stage(
+                CoreStage::PostUpdate,
+                ConditionSet::new()
+                    .run_in_state(GameState::InGame)
+                    .after(VelocitySystems)
+                    .with_system(camera_follow_player)
+                    .with_system(y_sort)
+                    .into(),
+            );
     }
 }
 
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, Default)]
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct YSort(f32);
 
 pub fn y_sort(mut query: Query<(&mut Transform, &YSort)>) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,10 @@ pub struct EngineConfig {
     #[structopt(short = "s", long)]
     pub auto_start: bool,
 
+    /// Enable the debug tools which can be accessed by pressing F12
+    #[structopt(short = "d", long)]
+    pub debug_tools: bool,
+
     /// Set the log level
     ///
     /// May additionally specify log levels for specific modules as a comma-separated list of
@@ -58,6 +62,12 @@ impl EngineConfig {
                 config.auto_start = auto_start;
             }
 
+            if let Some(debug_tools) =
+                parse_url_query_string(&query, "debug_tools").and_then(|s| s.parse().ok())
+            {
+                config.debug_tools = debug_tools;
+            }
+
             if let Some(log_level) = parse_url_query_string(&query, "log_level") {
                 config.log_level = log_level.into();
             }
@@ -77,6 +87,7 @@ impl EngineConfig {
             asset_dir: None,
             game_asset: "default.game.yaml".into(),
             auto_start: false,
+            debug_tools: false,
             log_level: DEFAULT_LOG_LEVEL.into(),
         }
     }

--- a/src/fighter.rs
+++ b/src/fighter.rs
@@ -34,8 +34,8 @@ pub struct ActiveFighterBundle {
     pub velocity: LinearVelocity,
 }
 
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, Deserialize, Clone, Debug)]
+#[derive(Component, Deserialize, Clone, Debug, Reflect)]
+#[reflect(Component)]
 #[serde(deny_unknown_fields)]
 pub struct Stats {
     pub max_health: i32,

--- a/src/loading/progress.rs
+++ b/src/loading/progress.rs
@@ -85,7 +85,17 @@ macro_rules! impl_default_load_progress {
         )*
     };
 }
-impl_default_load_progress!(String, f32, usize, u32, Vec2, Vec3, UVec2, egui::TextureId, bool);
+impl_default_load_progress!(
+    String,
+    f32,
+    usize,
+    u32,
+    Vec2,
+    Vec3,
+    UVec2,
+    egui::TextureId,
+    bool
+);
 
 // Implement `HasLoadProgress` for container types
 impl<T: HasLoadProgress> HasLoadProgress for Option<T> {

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -24,6 +24,13 @@ pub struct VelocitySystems;
 impl Plugin for MovementPlugin {
     fn build(&self, app: &mut App) {
         app
+            // Register our Reflect types
+            .register_type::<LinearVelocity>()
+            .register_type::<AngularVelocity>()
+            .register_type::<Force>()
+            .register_type::<Torque>()
+            // Init resources
+            .init_resource::<LeftMovementBoundary>()
             // Add systems that modify velocity based on forces
             .add_system_set_to_stage(
                 CoreStage::PostUpdate,
@@ -59,8 +66,8 @@ impl Plugin for MovementPlugin {
 ///
 /// This is similar to the velocity you would set in a physics simulation, but in our case we use a
 /// simple constraints system instead of actual physics simulation.
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, Deref, DerefMut, Default, Clone, Copy)]
+#[derive(Component, Deref, DerefMut, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct LinearVelocity(pub Vec2);
 
 /// System that updates translations based on entity velocities.
@@ -73,8 +80,8 @@ pub fn velocity_system(mut query: Query<(&mut Transform, &LinearVelocity)>, time
 /// An entity's angular velocity.
 ///
 /// A positive value means a clockwise rotation and a negative value means couter-clockwise.
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, Deref, DerefMut, Default)]
+#[derive(Component, Deref, DerefMut, Default, Reflect)]
+#[reflect(Component)]
 pub struct AngularVelocity(pub f32);
 
 impl AngularVelocity {
@@ -95,8 +102,8 @@ pub fn angular_velocity_system(
 }
 
 /// A force that while present continually modified an entity's linear velocity.
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, Deref, DerefMut, Default, Clone, Copy)]
+#[derive(Component, Deref, DerefMut, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct Force(pub Vec2);
 
 // Applies forces to linear velocities
@@ -107,8 +114,8 @@ pub fn force_system(mut query: Query<(&mut LinearVelocity, &Force)>, time: Res<T
 }
 
 /// A force that while present continually modified an entity's angular velocity
-#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
-#[derive(Component, Deref, DerefMut, Default, Clone, Copy)]
+#[derive(Component, Deref, DerefMut, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct Torque(pub f32);
 
 // Applies torques to angular velocities

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -4,7 +4,7 @@
 
 use async_channel::{Receiver, Sender};
 use bevy::{prelude::*, tasks::IoTaskPool, utils::HashMap};
-use iyes_loopless::state::NextState;
+use iyes_loopless::prelude::*;
 use serde::{de::DeserializeOwned, Serialize};
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -22,7 +22,8 @@ impl Plugin for PlatformPlugin {
         #[cfg(target_arch = "wasm32")]
         app.add_system(wasm::update_canvas_size);
 
-        app.init_resource::<Storage>();
+        app.init_resource::<Storage>()
+            .add_system(load_storage.run_in_state(GameState::LoadingStorage));
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,11 +3,15 @@ use bevy_egui::{egui, EguiContext, EguiInput, EguiPlugin, EguiSettings};
 use iyes_loopless::prelude::*;
 use leafwing_input_manager::prelude::ActionState;
 
-use crate::{assets::EguiFont, audio, input::MenuAction, metadata::GameMeta, GameState};
+use crate::{
+    assets::EguiFont, audio, config::ENGINE_CONFIG, input::MenuAction, metadata::GameMeta,
+    GameState,
+};
 
 pub mod hud;
 pub mod widgets;
 
+pub mod debug_tools;
 pub mod main_menu;
 pub mod pause_menu;
 
@@ -47,6 +51,10 @@ impl Plugin for UIPlugin {
                     .with_system(main_menu::main_menu_system)
                     .into(),
             );
+
+        if ENGINE_CONFIG.debug_tools {
+            app.add_system(debug_tools::debug_tools_window);
+        }
     }
 }
 

--- a/src/ui/debug_tools.rs
+++ b/src/ui/debug_tools.rs
@@ -1,0 +1,43 @@
+use bevy::prelude::*;
+use bevy_egui::*;
+use bevy_fluent::Localization;
+use bevy_inspector_egui::WorldInspectorParams;
+use bevy_rapier2d::prelude::DebugRenderContext;
+
+use crate::localization::LocalizationExt;
+
+/// System that renders the debug tools window which can be toggled by pressing F12
+pub fn debug_tools_window(
+    mut visible: Local<bool>,
+    mut egui_context: ResMut<EguiContext>,
+    localization: Res<Localization>,
+    input: Res<Input<KeyCode>>,
+    mut rapier_debug: ResMut<DebugRenderContext>,
+    mut inspector: ResMut<WorldInspectorParams>,
+) {
+    let ctx = egui_context.ctx_mut();
+
+    // Toggle window visibility
+    if input.just_pressed(KeyCode::F12) {
+        *visible = !*visible;
+    }
+
+    // Display debug tool window
+    egui::Window::new(localization.get("debug-tools"))
+        // ID is needed because title comes from localizaition which can change
+        .id(egui::Id::new("debug_tools"))
+        .open(&mut *visible)
+        .show(ctx, |ui| {
+            // Show collision shapes
+            ui.checkbox(
+                &mut rapier_debug.enabled,
+                localization.get("show-collision-shapes"),
+            );
+
+            // Show world inspector
+            ui.checkbox(
+                &mut inspector.enabled,
+                localization.get("show-world-inspector"),
+            );
+        });
+}

--- a/src/ui/main_menu.rs
+++ b/src/ui/main_menu.rs
@@ -44,6 +44,7 @@ pub fn spawn_main_menu_background(
             },
             ..default()
         })
+        .insert(Name::new("Main Menu Background"))
         .insert(MainMenuBackground);
 }
 


### PR DESCRIPTION
Closes #144.

The `Reflect` derives are used as a more universal way to get support for inspecting them with the Bevy Egui world inspector. 

We will need to derive reflect and register the types for scripting so we might as well not do that and derive `Inspectable`.

This also clears out some of the remaining system scheduling that was done in main.rs and should have been in a plugin.

Now you can show the debug tools menu with F12 and configure the visibility of collision boxes and the world inspector.