### PR TITLE
Fix YSort and add editable colliders

### DIFF
--- a/assets/fighters/bandit/bandit.fighter.yaml
+++ b/assets/fighters/bandit/bandit.fighter.yaml
@@ -1,5 +1,9 @@
 name: Bandit
 
+hurtbox:
+  size: [24, 12]
+  offset: [0, 0]
+
 stats:
   max_health: 150
   movement_speed: 150
@@ -42,8 +46,9 @@ attack:
     startup: 1
     active: 2
     recovery: 3
-  hitbox: [12, 12]
-  hitbox_offset: [24, 0]
+  hitbox:
+    size: [24, 24]
+    offset: [24, 0]
 
 audio:
   effects:

--- a/assets/fighters/big_bass/big_bass.fighter.yaml
+++ b/assets/fighters/big_bass/big_bass.fighter.yaml
@@ -1,5 +1,9 @@
 name: Bandit
 
+hurtbox:
+  size: [96, 32]
+  offset: [0, -16]
+
 stats:
   max_health: 350
   movement_speed: 75
@@ -42,8 +46,9 @@ attack:
     startup: 5
     active: 9
     recovery: 14
-  hitbox: [48, 48]
-  hitbox_offset: [0, 0]
+  hitbox:
+    size: [96, 32]
+    offset: [0, -69]
 
 audio:
   effects:

--- a/assets/fighters/brute/brute.fighter.yaml
+++ b/assets/fighters/brute/brute.fighter.yaml
@@ -1,5 +1,9 @@
 name: Brute
 
+hurtbox:
+  size: [24, 12]
+  offset: [0, 0]
+
 stats:
   max_health: 200
   movement_speed: 50
@@ -42,8 +46,9 @@ attack:
     startup: 2
     active: 3
     recovery: 7
-  hitbox: [12, 12]
-  hitbox_offset: [24, 0]
+  hitbox:
+    size: [24, 24]
+    offset: [24, 0]
 
 audio:
   effects: {}

--- a/assets/fighters/fishy/fishy.fighter.yaml
+++ b/assets/fighters/fishy/fishy.fighter.yaml
@@ -1,5 +1,9 @@
 name: Fishy The Fearsome
 
+hurtbox:
+  size: [24, 12]
+  offset: [0, 0]
+
 stats:
   max_health: 600
   movement_speed: 150
@@ -40,8 +44,9 @@ attack:
     startup: 1
     active: 2
     recovery: 4
-  hitbox: [16, 16]
-  hitbox_offset: [24, 0]
+  hitbox:
+    size: [32, 32]
+    offset: [32, 0]
 
 audio:
   effects:

--- a/assets/fighters/sharky/sharky.fighter.yaml
+++ b/assets/fighters/sharky/sharky.fighter.yaml
@@ -1,5 +1,9 @@
 name: Scrumptious Sharky
 
+hurtbox:
+  size: [24, 12]
+  offset: [0, 0]
+
 stats:
   max_health: 600
   movement_speed: 150
@@ -40,8 +44,9 @@ attack:
     startup: 1
     active: 2
     recovery: 4
-  hitbox: [16, 16]
-  hitbox_offset: [24, 0]
+  hitbox:
+    size: [32, 32]
+    offset: [32, 0]
 
 audio:
   effects:

--- a/assets/fighters/slinger/slinger.fighter.yaml
+++ b/assets/fighters/slinger/slinger.fighter.yaml
@@ -1,5 +1,9 @@
 name: Slinger
 
+hurtbox:
+  size: [24, 12]
+  offset: [0, 0]
+
 stats:
   max_health: 100
   movement_speed: 150
@@ -42,8 +46,9 @@ attack:
     startup: 1
     active: 2
     recovery: 3
-  hitbox: [12, 12]
-  hitbox_offset: [24, 0]
+  hitbox:
+    size: [24, 24]
+    offset: [24, 0]
 
 audio:
   effects: {}

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -65,8 +65,8 @@ fn activate_hitbox(
             {
                 if let Some(fighter_data) = fighter_assets.get(fighter_meta) {
                     commands.entity(entity).insert(Collider::cuboid(
-                        fighter_data.attack.hitbox.x,
-                        fighter_data.attack.hitbox.y,
+                        fighter_data.attack.hitbox.size.x / 2.,
+                        fighter_data.attack.hitbox.size.y / 2.,
                     ));
                 }
             }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -24,10 +24,13 @@ impl Plugin for CameraPlugin {
     }
 }
 
+/// Component to sort entities by their y position.
+/// Takes in a offset usually the sprite's height.
 #[derive(Component, Default, Reflect)]
 #[reflect(Component)]
-pub struct YSort(f32);
+pub struct YSort(pub f32);
 
+/// Applies the y-sorting to the entities Z position.
 pub fn y_sort(mut query: Query<(&mut Transform, &YSort)>) {
     for (mut transform, ysort) in query.iter_mut() {
         transform.translation.z = ysort.0 - transform.translation.y;

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
-use crate::consts;
+use crate::{consts, metadata::ColliderMeta};
 
 /// Empty struct simply for grouping collision layer constants.
 #[derive(Copy, Clone)]
@@ -29,6 +29,20 @@ pub struct PhysicsBundle {
     pub active_collision_types: ActiveCollisionTypes,
     pub collision_groups: CollisionGroups,
 }
+
+impl PhysicsBundle {
+    pub fn new(meta: &ColliderMeta, body_layers: u32) -> Self {
+        PhysicsBundle {
+            collider: (Collider::cuboid(meta.size.x / 2., meta.size.y / 2.)),
+            sensor: Sensor,
+            active_events: ActiveEvents::COLLISION_EVENTS,
+            active_collision_types: ActiveCollisionTypes::default()
+                | ActiveCollisionTypes::STATIC_STATIC,
+            collision_groups: CollisionGroups::new(body_layers, BodyLayers::ALL),
+        }
+    }
+}
+
 impl Default for PhysicsBundle {
     fn default() -> Self {
         PhysicsBundle {

--- a/src/fighter.rs
+++ b/src/fighter.rs
@@ -58,8 +58,6 @@ impl Default for Stats {
 }
 
 /// Turns a fighter stub data (loaded from the metadata) into a fully active fighter.
-///
-/// PS: The position of the fighter corresponds the bottom center of the sprite.
 impl ActiveFighterBundle {
     pub fn activate_fighter_stub(
         commands: &mut Commands,

--- a/src/fighter.rs
+++ b/src/fighter.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy_rapier2d::prelude::CollisionGroups;
 use rand::prelude::SliceRandom;
 use serde::Deserialize;
 
@@ -59,6 +58,8 @@ impl Default for Stats {
 }
 
 /// Turns a fighter stub data (loaded from the metadata) into a fully active fighter.
+///
+/// PS: The position of the fighter corresponds the bottom center of the sprite.
 impl ActiveFighterBundle {
     pub fn activate_fighter_stub(
         commands: &mut Commands,
@@ -80,7 +81,7 @@ impl ActiveFighterBundle {
             name: Name::new(fighter.name.clone()),
             animated_spritesheet_bundle: AnimatedSpriteSheetBundle {
                 sprite_sheet: SpriteSheetBundle {
-                    sprite: TextureAtlasSprite::new(0),
+                    sprite: default(),
                     texture_atlas: fighter
                         .spritesheet
                         .atlas_handle
@@ -99,13 +100,10 @@ impl ActiveFighterBundle {
             health: Health(fighter.stats.max_health),
             inventory: default(),
             damageable: default(),
-            physics_bundle: PhysicsBundle {
-                collision_groups: CollisionGroups::new(body_layers, BodyLayers::ALL),
-                ..default()
-            },
+            physics_bundle: PhysicsBundle::new(&fighter.hurtbox, body_layers),
             idling: Idling,
             state_transition_intents: default(),
-            ysort: default(),
+            ysort: YSort(fighter.spritesheet.tile_size.x as f32),
             velocity: default(),
         };
 

--- a/src/fighter_state.rs
+++ b/src/fighter_state.rs
@@ -679,9 +679,9 @@ fn punching(
                 // Start the attack  from the beginning
                 animation.play(Punching::ANIMATION, false);
 
-                let mut offset = fighter.attack.hitbox_offset;
+                let mut offset = fighter.attack.hitbox.offset;
                 if facing.is_left() {
-                    offset *= -1.0
+                    offset.x *= -1.0
                 }
                 let attack_frames = fighter.attack.frames;
                 // Spawn the attack entity
@@ -764,7 +764,7 @@ fn ground_slam(
     {
         // Start the attack
         if let Some(fighter) = fighter_assets.get(meta_handle) {
-            let mut offset = fighter.attack.hitbox_offset;
+            let mut offset = fighter.attack.hitbox.offset;
             if facing.is_left() {
                 offset *= -1.0
             }

--- a/src/fighter_state.rs
+++ b/src/fighter_state.rs
@@ -766,7 +766,7 @@ fn ground_slam(
         if let Some(fighter) = fighter_assets.get(meta_handle) {
             let mut offset = fighter.attack.hitbox.offset;
             if facing.is_left() {
-                offset *= -1.0
+                offset.x *= -1.0
             }
             let attack_frames = fighter.attack.frames;
             if !ground_slam.has_started {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -91,6 +91,7 @@ pub struct FighterMeta {
     pub hud: FighterHudMeta,
     pub spritesheet: FighterSpritesheetMeta,
     pub audio: AudioMeta,
+    pub hurtbox: ColliderMeta,
     //Will likely need a hashmap(?) of AttackMetas, fighters will have multiple attacks
     pub attack: AttackMeta,
 }
@@ -102,8 +103,7 @@ pub struct AttackMeta {
     pub name: String,
     pub damage: i32,
     pub frames: AttackFrames,
-    pub hitbox: Vec2,
-    pub hitbox_offset: Vec2,
+    pub hitbox: ColliderMeta,
 }
 
 #[derive(TypeUuid, Deserialize, Clone, Debug, Component)]
@@ -220,4 +220,12 @@ impl From<ParallaxLayerMeta> for LayerData {
             position: meta.position,
         }
     }
+}
+
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ColliderMeta {
+    //TODO: Add type of collider with different properties.
+    pub size: Vec2,
+    pub offset: Vec2,
 }


### PR DESCRIPTION
It fixes y-sorting by using the offset in the `YSort `component (not in use before), also implements hurtboxes and updates hitboxes by using a `ColliderMeta`.

Currently, the hurtbox offset is not implemented since it would require spawning the sensor has a child and I'm not sure if that's necessary, at least for now.