### PR TITLE
Add projectile despawning on collision.

### DIFF
--- a/src/attack.rs
+++ b/src/attack.rs
@@ -41,16 +41,21 @@ pub struct Attack {
     pub velocity: Vec2,
 }
 
-/// A component that depawns an entity after collision with tolerance to x collisions.
+/// A component that depawns an entity after collision.
 #[derive(Component, Clone, Copy, Default, Reflect)]
 pub struct Breakable {
-    pub hits: i32,
-    count: i32,
+    /// The number of collisions allowed before the entity is breakable.
+    pub hit_tolerance: i32,
+    /// The number of collisions occured.
+    pub hit_count: i32,
 }
 
 impl Breakable {
     pub fn new(hits: i32) -> Self {
-        Self { hits, count: 0 }
+        Self {
+            hit_tolerance: hits,
+            hit_count: 0,
+        }
     }
 }
 
@@ -147,8 +152,8 @@ fn breakable_system(
         if let CollisionEvent::Started(e1, e2, _flags) = ev {
             for e in [e1, e2].iter() {
                 if let Ok(mut breakable) = despawn_query.get_mut(**e) {
-                    if breakable.count < breakable.hits {
-                        breakable.count += 1;
+                    if breakable.hit_count < breakable.hit_tolerance {
+                        breakable.hit_count += 1;
                     } else {
                         commands.entity(**e).despawn_recursive();
                     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 use crate::{
     animation::Facing,
-    attack::{Attack, DespawnOnCollision},
+    attack::{Attack, Breakable},
     collision::BodyLayers,
     consts,
     lifetime::Lifetime,
@@ -55,7 +55,7 @@ pub struct Projectile {
     collision_groups: CollisionGroups,
     attack: Attack,
     lifetime: Lifetime,
-    deswawn_on_collision: DespawnOnCollision,
+    breakable: Breakable,
 }
 
 impl Projectile {
@@ -91,7 +91,7 @@ impl Projectile {
             //files of fighter which "team" they are on
             collision_groups: CollisionGroups::new(BodyLayers::PLAYER_ATTACK, BodyLayers::ENEMY),
             lifetime: Lifetime(Timer::from_seconds(consts::THROW_ITEM_LIFETIME, false)),
-            deswawn_on_collision: DespawnOnCollision(0),
+            breakable: Breakable::new(0),
         }
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 use crate::{
     animation::Facing,
-    attack::Attack,
+    attack::{Attack, DespawnOnCollision},
     collision::BodyLayers,
     consts,
     lifetime::Lifetime,
@@ -55,6 +55,7 @@ pub struct Projectile {
     collision_groups: CollisionGroups,
     attack: Attack,
     lifetime: Lifetime,
+    deswawn_on_collision: DespawnOnCollision,
 }
 
 impl Projectile {
@@ -90,6 +91,7 @@ impl Projectile {
             //files of fighter which "team" they are on
             collision_groups: CollisionGroups::new(BodyLayers::PLAYER_ATTACK, BodyLayers::ENEMY),
             lifetime: Lifetime(Timer::from_seconds(consts::THROW_ITEM_LIFETIME, false)),
+            deswawn_on_collision: DespawnOnCollision(0),
         }
     }
 }


### PR DESCRIPTION
Added a new `DespawnOnCollision` component that takes a number of collisions before it is respawned on collision. Added this component to the projectile bundle with the value of 0.

I do not really like the naming on this one, open to ideas :), should fix #210.