### PR TITLE
Change Y-Sort value to represent the base Z value

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -25,8 +25,8 @@ impl Plugin for CameraPlugin {
 }
 
 /// Component to sort entities by their y position.
-/// Takes in a offset usually the sprite's height.
-/// the offset is currently unused, but may be used again if we implement virtual z for jumping
+/// Takes in a base value usually the sprite default Z with possibly an height offset.
+/// this value could be tweaked to implement virtual Z for jumping
 #[derive(Component, Default, Reflect)]
 #[reflect(Component)]
 pub struct YSort(pub f32);
@@ -34,9 +34,7 @@ pub struct YSort(pub f32);
 /// Applies the y-sorting to the entities Z position.
 pub fn y_sort(mut query: Query<(&mut Transform, &YSort)>) {
     for (mut transform, ysort) in query.iter_mut() {
-        //temporary fix for boss being able to move behind parallax, consider removing the 300.
-        //offset or moving to a const
-        transform.translation.z = ysort.0 + 300. - transform.translation.y;
+        transform.translation.z = ysort.0 - transform.translation.y;
     }
 }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,6 +3,8 @@ use bevy::math::Vec2;
 pub const PLAYER_SPRITE_WIDTH: f32 = 96.;
 pub const PLAYER_HITBOX_HEIGHT: f32 = 50.;
 
+pub const FIGHTERS_Z: f32 = 300.;
+
 /// Absolute value.
 pub const ENEMY_TARGET_MAX_OFFSET: f32 = 40.;
 

--- a/src/fighter.rs
+++ b/src/fighter.rs
@@ -3,7 +3,7 @@ use rand::prelude::SliceRandom;
 use serde::Deserialize;
 
 use crate::attack::Hurtbox;
-use crate::consts::FOOT_PADDING;
+use crate::consts::{self, FOOT_PADDING};
 use crate::metadata::ItemMeta;
 use crate::{
     animation::{AnimatedSpriteSheetBundle, Animation},
@@ -111,7 +111,7 @@ impl ActiveFighterBundle {
             idling: Idling,
             state_transition_intents: default(),
             // ysort: YSort(fighter.spritesheet.tile_size.y as f32 / 2.),
-            ysort: YSort(0.),
+            ysort: YSort(consts::FIGHTERS_Z),
             velocity: default(),
         };
         let hurtbox = commands


### PR DESCRIPTION
Basically, the Y-Sort should take a value with the default Z and maybe some offset if necessary.
Currently, the default Z is defined as a constant with a value of 300. 